### PR TITLE
Fix counting of partitionable slots.

### DIFF
--- a/frontend/glideinFrontendElement.py
+++ b/frontend/glideinFrontendElement.py
@@ -1216,6 +1216,7 @@ class glideinFrontendElement:
                 ('GLIDEIN_CredentialIdentifier', 's'),
                 ('TotalSlots', 'i'),
                 ('Cpus', 'i'),
+                ('Memory', 'i'),
                 ('PartitionableSlot', 's'),
             ]
 


### PR DESCRIPTION
This fixes a few frontend issues when using p-slots:
- Count a p-slot as idle if it has non-zero cores and a non-trivial amount
  of free memory.  This fixes a idle-count issue when the limiting resource
  is memory, not CPUs.  It's not a complete fix - it would not detect issues
  from running out of disk space.  A complete fix would require consumption
  policies - a fairly fundamental overhaul of the code.
- Allow p-slots to be counted as running if they have any associated dynamic
  slots.  This is essential - since the jobs report the RemoteHost as the
  p-slot, if we don't count the p-slot as running, the entry point is listed
  as having no running jobs.  This causes MaxRunning requests to be incorrectly
  (severly) curtailed.
- As each p-slot is listed as having multiple jobs running, we drastically
  over-count the number of running glideins.  When there are idle jobs,
  MaxRunning>running.  Hence, if we over-count the running glideins, the
  MaxRunning request may be too large - for 8-core slots, up to a factor of 8!
  - NOTE: there are several places in the monitoring that assume this statistic
    is actually the number of running jobs, not the running glideins.  I made
    the conscious decision that getting MaxRunning correct is more important
    than the monitoring at this point.